### PR TITLE
Fix point normal form, and modifications to method

### DIFF
--- a/ipm_library/ipm_library/ipm.py
+++ b/ipm_library/ipm_library/ipm.py
@@ -121,11 +121,11 @@ class IPM:
         assert self._camera_info.header.frame_id == points_header.frame_id, \
             'Points need to be in frame described in the camera info message'
 
-        # Convert plane to normal format
-        plane = utils.transform_to_normal_plane(plane_msg.plane)
+        # Convert plane from general form to point normal form
+        plane = utils.plane_general_to_point_normal(plane_msg.plane)
 
         # View plane from camera frame
-        plane_normal, plane_base_point = utils.transform_plane_to_frame(
+        plane_base_point, plane_normal = utils.transform_plane_to_frame(
             plane=plane,
             input_frame=plane_msg.header.frame_id,
             output_frame=self._camera_info.header.frame_id,

--- a/ipm_library/test/test_ipm.py
+++ b/ipm_library/test/test_ipm.py
@@ -64,7 +64,7 @@ def test_ipm_project_point_no_transform():
     plane = PlaneStamped()
     plane.header.frame_id = 'camera_optical_frame'
     plane.plane.coef[2] = 1.0  # Normal in z direction
-    plane.plane.coef[3] = 1.0  # 1 meter distance
+    plane.plane.coef[3] = -1.0  # 1 meter distance
     # Create PointStamped with the center pixel of the camera
     point = PointStamped()
     point.header = cam.header
@@ -107,7 +107,7 @@ def test_ipm_project_points_no_transform():
     plane = PlaneStamped()
     plane.header.frame_id = 'camera_optical_frame'
     plane.plane.coef[2] = 1.0  # Normal in z direction
-    plane.plane.coef[3] = 1.0  # 1 meter distance
+    plane.plane.coef[3] = -1.0  # 1 meter distance
     # Create two Points on the center pixel of the camera
     points = np.array([
         # Center
@@ -151,7 +151,7 @@ def test_ipm_project_point_no_transform_no_intersection():
     plane = PlaneStamped()
     plane.header.frame_id = 'camera_optical_frame'
     plane.plane.coef[2] = 1.0  # Normal in z direction
-    plane.plane.coef[3] = -1.0  # 1 meter distance
+    plane.plane.coef[3] = 1.0  # 1 meter distance
     # Create PointStamped with the center pixel of the camera
     point = PointStamped()
     point.header = cam.header
@@ -183,7 +183,7 @@ def test_ipm_project_points_no_transform_no_intersection():
     plane = PlaneStamped()
     plane.header.frame_id = 'camera_optical_frame'
     plane.plane.coef[2] = 1.0  # Normal in z direction
-    plane.plane.coef[3] = -1.0  # 1 meter distance
+    plane.plane.coef[3] = 1.0  # 1 meter distance
     # Create two Points on the center pixel of the camera
     points = np.array([
         # Corner

--- a/ipm_library/test/test_utils.py
+++ b/ipm_library/test/test_utils.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2022 Kenji Brameld
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ipm_library.utils import plane_general_to_point_normal
+import numpy as np
+from shape_msgs.msg import Plane
+
+
+def test_plane_general_to_point_normal_1():
+    plane = Plane(coef=[2.0, 0.0, 0.0, -4.0])  # x = 2.0 (2.0x + 0y + 0z - 4.0 = 0)
+    (n, p) = plane_general_to_point_normal(plane)
+    assert np.allclose(n, [2.0, 0.0, 0.0], rtol=0.0001)
+    assert np.allclose(p, [1.0, 0.0, 0.0], rtol=0.0001)
+
+
+def test_plane_general_to_point_normal_2():
+    plane = Plane(coef=[0.0, 0.0, -1.0, -1.0])  # z = -1.0 (0x + 0y - 1.0z - 1.0 = 0)
+    (n, p) = plane_general_to_point_normal(plane)
+    assert np.allclose(n, [0.0, 0.0, -1.0], rtol=0.0001)
+    assert np.allclose(p, [0.0, 0.0, -1.0], rtol=0.0001)


### PR DESCRIPTION
There was an issue where the equations used currently were assuming the general plane form to be  ``ax+by+cz=d``, whereas the general plane form used in Plane.msg is actually ``ax+by+cz+d=0``. (So d was the negative of what it actually should be).

I've also renamed the ``transform_to_normal_plane`` to ``plane_general_to_point_normal``, which returns (point, normal) rather than (normal, point) since this seems more natural with the term "point-normal form".

Added tests in test/test_utils.py to confirm correct conversion.