### PR TITLE
Reorder package.xml and CMakeLists.txt to alphabetical order

### DIFF
--- a/ipm_library/package.xml
+++ b/ipm_library/package.xml
@@ -7,19 +7,19 @@
   <maintainer email="git@flova.de">Florian Vahl</maintainer>
   <license>Apache License 2.0</license>
 
+  <depend>geometry_msgs</depend>
+  <depend>ipm_msgs</depend>
+  <depend>python3-numpy</depend>
+  <depend>sensor_msgs</depend>
+  <depend>shape_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+
   <test_depend>ament_copyright</test_depend>
   <test_depend>ament_flake8</test_depend>
   <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
-
-  <depend>std_msgs</depend>
-  <depend>sensor_msgs</depend>
-  <depend>shape_msgs</depend>
-  <depend>ipm_msgs</depend>
-  <depend>geometry_msgs</depend>
-  <depend>tf2_geometry_msgs</depend>
-  <depend>tf2</depend>
-  <depend>python3-numpy</depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ipm_msgs/CMakeLists.txt
+++ b/ipm_msgs/CMakeLists.txt
@@ -8,8 +8,8 @@ endif()
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(std_msgs REQUIRED)
 find_package(shape_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -18,7 +18,7 @@ endif()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PlaneStamped.msg"
-  DEPENDENCIES std_msgs shape_msgs
+  DEPENDENCIES shape_msgs std_msgs
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/ipm_msgs/package.xml
+++ b/ipm_msgs/package.xml
@@ -7,18 +7,18 @@
   <maintainer email="git@flova.de">Florian Vahl</maintainer>
   <license>Apache License 2.0</license>
 
+  <build_depend>rosidl_default_generators</build_depend>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>std_msgs</depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
   <depend>shape_msgs</depend>
+  <depend>std_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
-  
-  <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <build_depend>rosidl_default_generators</build_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>


### PR DESCRIPTION
Having a specific order is nice, and would prevent simple mistakes like the duplicated ``<exec_depend>rosidl_default_runtime</exec_depend>`` in ``ipm_msgs/package.xml``.