### PR TITLE
remove point2dstamped

### DIFF
--- a/ipm_interfaces/CMakeLists.txt
+++ b/ipm_interfaces/CMakeLists.txt
@@ -21,7 +21,6 @@ endif()
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/PlaneStamped.msg"
-  "msg/Point2DStamped.msg"
   "srv/MapPoint.srv"
   "srv/MapPointCloud2.srv"
   DEPENDENCIES geometry_msgs sensor_msgs shape_msgs std_msgs vision_msgs

--- a/ipm_interfaces/msg/Point2DStamped.msg
+++ b/ipm_interfaces/msg/Point2DStamped.msg
@@ -1,4 +1,0 @@
-# This represents a Point2D with reference coordinate frame and timestamp
-
-std_msgs/Header header
-vision_msgs/Point2D point

--- a/ipm_interfaces/srv/MapPoint.srv
+++ b/ipm_interfaces/srv/MapPoint.srv
@@ -1,5 +1,5 @@
 ipm_interfaces/PlaneStamped plane
-ipm_interfaces/Point2DStamped point
+vision_msgs/Point2D point
 std_msgs/String output_frame
 ---
 # Result code defintions

--- a/ipm_library/test/test_ipm.py
+++ b/ipm_library/test/test_ipm.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from geometry_msgs.msg import TransformStamped
-from ipm_interfaces.msg import PlaneStamped, Point2DStamped
+from ipm_interfaces.msg import PlaneStamped
 from ipm_library.exceptions import InvalidPlaneException, NoIntersectionError
 from ipm_library.ipm import IPM
 import numpy as np
@@ -65,12 +65,11 @@ def test_ipm_map_point_no_transform():
     plane.header.frame_id = 'camera_optical_frame'
     plane.plane.coef[2] = 1.0  # Normal in z direction
     plane.plane.coef[3] = -1.0  # 1 meter distance
-    # Create Point2DStamped to be projected
+    # Create Point2D to be projected
     point_original_x = 100.0  # in pixels
     point_original_y = 200.0  # in pixels
     point_original = np.array([[point_original_x], [point_original_y]])
-    point_original_msg = Point2DStamped(
-        header=cam.header, point=Point2D(x=point_original_x, y=point_original_y))
+    point_original_msg = Point2D(x=point_original_x, y=point_original_y)
     # Map points
     point_mapped_msg = ipm.map_point(plane, point_original_msg)
     # Check header
@@ -123,7 +122,7 @@ def test_ipm_map_points_no_transform():
         [0, 0, 0]
     ])
     # Map points
-    points_mapped = ipm.map_points(plane, points, cam.header)
+    points_mapped = ipm.map_points(plane, points)
     # Make goal points array, x and y are not exactly 0 because of the camera calibration as
     # well as an uneven amount of pixels
     goal_point_array = np.array([
@@ -136,7 +135,7 @@ def test_ipm_map_points_no_transform():
 
 
 def test_ipm_map_point_no_transform_no_intersection():
-    """Impossible mapping of Point2DStamped without doing any tf transforms."""
+    """Impossible mapping of Point2D without doing any tf transforms."""
     # We need to create a dummy tf buffer
     tf_buffer = tf2.Buffer()
     # Dummy camera info
@@ -156,11 +155,10 @@ def test_ipm_map_point_no_transform_no_intersection():
     plane.header.frame_id = 'camera_optical_frame'
     plane.plane.coef[2] = 1.0  # Normal in z direction
     plane.plane.coef[3] = 1.0  # 1 meter distance
-    # Create Point2DStamped with the center pixel of the camera
-    point = Point2DStamped()
-    point.header = cam.header
-    point.point.x = float(cam.width // cam.binning_x // 2)
-    point.point.y = float(cam.height // cam.binning_y // 2)
+    # Create Point2D with the center pixel of the camera
+    point = Point2D()
+    point.x = float(cam.width // cam.binning_x // 2)
+    point.y = float(cam.height // cam.binning_y // 2)
     # Test if a NoIntersectionError is raised
     with pytest.raises(NoIntersectionError):
         # Map points
@@ -194,7 +192,7 @@ def test_ipm_map_points_no_transform_no_intersection():
         [0, 0, 0]
     ])
     # Map points
-    points_mapped = ipm.map_points(plane, points, cam.header)
+    points_mapped = ipm.map_points(plane, points)
     # Make goal points array, x and y are not exactly 0 because of the camera calibration as
     # well as an uneven amount of pixels
     goal_point_array = np.array([
@@ -207,7 +205,7 @@ def test_ipm_map_points_no_transform_no_intersection():
 
 
 def test_ipm_map_point():
-    """Map Point2DStamped with tf transforms."""
+    """Map Point2D with tf transforms."""
     # We need to create a dummy tf buffer
     tf_buffer = tf2.Buffer()
     transform = TransformStamped()
@@ -232,11 +230,10 @@ def test_ipm_map_point():
     plane = PlaneStamped()
     plane.header.frame_id = 'base_footprint'
     plane.plane.coef[2] = 1.0  # Normal in z direction
-    # Create Point2DStamped with the center pixel of the camera
-    point = Point2DStamped()
-    point.header = cam.header
-    point.point.x = float(cam.width // cam.binning_x // 2)
-    point.point.y = float(cam.height // cam.binning_y // 2)
+    # Create Point2D with the center pixel of the camera
+    point = Point2D()
+    point.x = float(cam.width // cam.binning_x // 2)
+    point.y = float(cam.height // cam.binning_y // 2)
     # Map points
     point_mapped = ipm.map_point(
         plane, point, output_frame=plane.header.frame_id)
@@ -295,7 +292,6 @@ def test_ipm_map_points():
     points_mapped = ipm.map_points(
         plane,
         points=points,
-        points_header=cam.header,
         output_frame=plane.header.frame_id)
     # Make goal points array, x and y are not exactly 0 because of the camera calibration as
     # well as an uneven amount of pixels
@@ -312,11 +308,11 @@ def test_map_point_invalid_plane_exception():
     """Check InvalidPlaneException is raised if a plane is invalid, i.e. a=b=c=0."""
     ipm = IPM(tf2.Buffer(), CameraInfo())
     with pytest.raises(InvalidPlaneException):
-        ipm.map_point(PlaneStamped(), Point2DStamped())
+        ipm.map_point(PlaneStamped(), Point2D())
 
 
 def test_map_points_invalid_plane_exception():
     """Check InvalidPlaneException is raised if a plane is invalid, i.e. a=b=c=0."""
     ipm = IPM(tf2.Buffer(), CameraInfo())
     with pytest.raises(InvalidPlaneException):
-        ipm.map_points(PlaneStamped(), np.array([]), Header())
+        ipm.map_points(PlaneStamped(), np.array([]))

--- a/ipm_service/ipm_service/ipm.py
+++ b/ipm_service/ipm_service/ipm.py
@@ -107,7 +107,6 @@ class IPMService(Node):
             mapped_points = self.ipm.map_points(
                 request.plane,
                 read_points_numpy(request.points),
-                request.points.header,
                 output_frame)
 
             # Convert them into a PointCloud2

--- a/ipm_service/test/test_ipm_service.py
+++ b/ipm_service/test/test_ipm_service.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ipm_interfaces.msg import PlaneStamped, Point2DStamped
+from ipm_interfaces.msg import PlaneStamped
 from ipm_interfaces.srv import MapPoint, MapPointCloud2
 from ipm_library.ipm import IPM
 from ipm_service.ipm import IPMService
@@ -137,9 +137,7 @@ def test_map_point():
     camera_info_pub.publish(camera_info)
     rclpy.spin_once(ipm_service_node, timeout_sec=0.1)
 
-    point = Point2DStamped(
-        header=Header(frame_id='camera_optical_frame'),
-        point=Point2D(x=100.0, y=100.0))
+    point = Point2D(x=100.0, y=100.0)
 
     # XY-plane at z = 1.0
     # Create Plane in the same frame as our camera with 1m distance facing the camera
@@ -257,8 +255,7 @@ def test_map_point_cloud():
     assert future.result().result == MapPointCloud2.Response.RESULT_SUCCESS
 
     ipm = IPM(Buffer(), camera_info)
-    expected_points = ipm.map_points(
-        plane, points, point_cloud.header)
+    expected_points = ipm.map_points(plane, points)
 
     np.testing.assert_allclose(
         read_points_numpy(future.result().points),


### PR DESCRIPTION
Removing Point2DStamped removes the need for sanity checking that frame_id and timestamp matches between the different msgs.

The Point2D will always be in image coordinates, and the timestamp from the PlaneStamped will be used for transforms.