### PR TITLE
reuse camera info in tests, rather than redfining in each method

### DIFF
--- a/ipm_library/test/test_ipm.py
+++ b/ipm_library/test/test_ipm.py
@@ -26,13 +26,22 @@ from std_msgs.msg import Header
 import tf2_ros as tf2
 from vision_msgs.msg import Point2D
 
+# Sample camera info
+cam = CameraInfo(
+    header=Header(
+        frame_id='camera_optical_frame',
+    ),
+    width=2048,
+    height=1536,
+    binning_x=4,
+    binning_y=4,
+    k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
+
 
 def test_ipm_camera_info():
     """Test if the camera info is handled correctly."""
     # We need to create a dummy tf buffer
     tf_buffer = tf2.Buffer()
-    # Dummy camera info
-    cam = CameraInfo()
     # Create an IPM
     ipm1 = IPM(tf_buffer, cam)
     assert ipm1.camera_info_received(), 'Failed to set camera info in constructor'
@@ -51,16 +60,6 @@ def test_ipm_map_point_no_transform():
     """Map PointStamped without doing any tf transforms."""
     # We need to create a dummy tf buffer
     tf_buffer = tf2.Buffer()
-    # Dummy camera info
-    cam = CameraInfo(
-        header=Header(
-            frame_id='camera_optical_frame',
-        ),
-        width=2048,
-        height=1536,
-        binning_x=4,
-        binning_y=4,
-        k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
     # Create an IPM
     ipm = IPM(tf_buffer, cam)
     # Create Plane in the same frame as our camera with 1m distance facing the camera
@@ -98,16 +97,6 @@ def test_ipm_map_points_no_transform():
     """Map points from NumPy array without doing any tf transforms."""
     # We need to create a dummy tf buffer
     tf_buffer = tf2.Buffer()
-    # Dummy camera info
-    cam = CameraInfo(
-        header=Header(
-            frame_id='camera_optical_frame',
-        ),
-        width=2048,
-        height=1536,
-        binning_x=4,
-        binning_y=4,
-        k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
     # Create an IPM
     ipm = IPM(tf_buffer, cam)
     # Create Plane in the same frame as our camera with 1m distance facing the camera
@@ -142,16 +131,6 @@ def test_ipm_map_point_no_transform_no_intersection():
     """Impossible mapping of Point2DStamped without doing any tf transforms."""
     # We need to create a dummy tf buffer
     tf_buffer = tf2.Buffer()
-    # Dummy camera info
-    cam = CameraInfo(
-        header=Header(
-            frame_id='camera_optical_frame',
-        ),
-        width=2048,
-        height=1536,
-        binning_x=4,
-        binning_y=4,
-        k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
     # Create an IPM
     ipm = IPM(tf_buffer, cam)
     # Create Plane in the same frame as our camera but 1m behind it
@@ -174,16 +153,6 @@ def test_ipm_map_points_no_transform_no_intersection():
     """Impossible mapping of points from NumPy array without doing any tf transforms."""
     # We need to create a dummy tf buffer
     tf_buffer = tf2.Buffer()
-    # Dummy camera info
-    cam = CameraInfo(
-        header=Header(
-            frame_id='camera_optical_frame',
-        ),
-        width=2048,
-        height=1536,
-        binning_x=4,
-        binning_y=4,
-        k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
     # Create an IPM
     ipm = IPM(tf_buffer, cam)
     # Create Plane in the same frame as our camera with 1m distance facing the camera
@@ -219,16 +188,6 @@ def test_ipm_map_point():
     transform.transform.rotation.w = 1.0
     transform.transform.translation.z = 1.0
     tf_buffer.set_transform_static(transform, '')
-    # Dummy camera info
-    cam = CameraInfo(
-        header=Header(
-            frame_id='camera_optical_frame',
-        ),
-        width=2048,
-        height=1536,
-        binning_x=4,
-        binning_y=4,
-        k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
     # Create an IPM
     ipm = IPM(tf_buffer, cam)
     # Create Plane in the same frame as our camera with 1m distance facing the camera
@@ -268,16 +227,6 @@ def test_ipm_map_points():
     transform.transform.rotation.w = 1.0
     transform.transform.translation.z = 1.0
     tf_buffer.set_transform_static(transform, '')
-    # Dummy camera info
-    cam = CameraInfo(
-        header=Header(
-            frame_id='camera_optical_frame',
-        ),
-        width=2048,
-        height=1536,
-        binning_x=4,
-        binning_y=4,
-        k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
     # Create an IPM
     ipm = IPM(tf_buffer, cam)
     # Create Plane in the same frame as our camera with 1m distance facing the camera

--- a/ipm_library/test/test_ipm.py
+++ b/ipm_library/test/test_ipm.py
@@ -262,14 +262,14 @@ def test_ipm_map_points():
 
 def test_map_point_invalid_plane_exception():
     """Check InvalidPlaneException is raised if a plane is invalid, i.e. a=b=c=0."""
-    ipm = IPM(tf2.Buffer(), CameraInfo())
+    ipm = IPM(tf2.Buffer(), cam)
     with pytest.raises(InvalidPlaneException):
         ipm.map_point(PlaneStamped(), Point2DStamped())
 
 
 def test_map_points_invalid_plane_exception():
     """Check InvalidPlaneException is raised if a plane is invalid, i.e. a=b=c=0."""
-    ipm = IPM(tf2.Buffer(), CameraInfo())
+    ipm = IPM(tf2.Buffer(), cam)
     with pytest.raises(InvalidPlaneException):
         ipm.map_points(PlaneStamped(), np.array([]), Header())
 

--- a/ipm_library/test/test_ipm.py
+++ b/ipm_library/test/test_ipm.py
@@ -42,18 +42,20 @@ def test_ipm_camera_info():
     """Test if the camera info is handled correctly."""
     # We need to create a dummy tf buffer
     tf_buffer = tf2.Buffer()
+    # Empty camera info
+    empty_camera_info = CameraInfo()
     # Create an IPM
-    ipm1 = IPM(tf_buffer, camera_info)
+    ipm1 = IPM(tf_buffer, empty_camera_info)
     assert ipm1.camera_info_received(), 'Failed to set camera info in constructor'
     # Create another IPM without the CameraInfo
     ipm2 = IPM(tf_buffer)
     assert not ipm2.camera_info_received(), 'Missing camera info not recognized'
     # Set camera info
-    ipm2.set_camera_info(camera_info)
+    ipm2.set_camera_info(empty_camera_info)
     assert ipm1.camera_info_received(), 'Failed to set camera info'
     # Set another camera info
     ipm2.set_camera_info(CameraInfo(header=Header(frame_id='test')))
-    assert ipm2._camera_info != camera_info, 'Camera info not updated'
+    assert ipm2._camera_info != empty_camera_info, 'Camera info not updated'
 
 
 def test_ipm_map_point_no_transform():
@@ -262,14 +264,14 @@ def test_ipm_map_points():
 
 def test_map_point_invalid_plane_exception():
     """Check InvalidPlaneException is raised if a plane is invalid, i.e. a=b=c=0."""
-    ipm = IPM(tf2.Buffer(), camera_info)
+    ipm = IPM(tf2.Buffer(), CameraInfo())
     with pytest.raises(InvalidPlaneException):
         ipm.map_point(PlaneStamped(), Point2DStamped())
 
 
 def test_map_points_invalid_plane_exception():
     """Check InvalidPlaneException is raised if a plane is invalid, i.e. a=b=c=0."""
-    ipm = IPM(tf2.Buffer(), camera_info)
+    ipm = IPM(tf2.Buffer(), CameraInfo())
     with pytest.raises(InvalidPlaneException):
         ipm.map_points(PlaneStamped(), np.array([]), Header())
 

--- a/ipm_service/test/test_ipm_service.py
+++ b/ipm_service/test/test_ipm_service.py
@@ -25,6 +25,17 @@ from std_msgs.msg import Header
 from tf2_ros import Buffer
 from vision_msgs.msg import Point2D
 
+# Sample camera info
+camera_info = CameraInfo(
+    header=Header(
+        frame_id='camera_optical_frame',
+    ),
+    width=2048,
+    height=1536,
+    binning_x=4,
+    binning_y=4,
+    k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
+
 
 def test_topics_and_services():
 
@@ -74,7 +85,6 @@ def test_map_point_invalid_plane():
     test_node = rclpy.node.Node('test')
 
     camera_info_pub = test_node.create_publisher(CameraInfo, 'camera_info', 10)
-    camera_info = CameraInfo()
     camera_info_pub.publish(camera_info)
     rclpy.spin_once(ipm_service_node, timeout_sec=0.1)
 
@@ -98,12 +108,6 @@ def test_map_point_no_intersection_error():
     test_node = rclpy.node.Node('test')
 
     camera_info_pub = test_node.create_publisher(CameraInfo, 'camera_info', 10)
-    camera_info = CameraInfo(
-        width=2048,
-        height=1536,
-        binning_x=4,
-        binning_y=4,
-        k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
     camera_info_pub.publish(camera_info)
     rclpy.spin_once(ipm_service_node, timeout_sec=0.1)
 
@@ -127,13 +131,6 @@ def test_map_point():
     test_node = rclpy.node.Node('test')
 
     camera_info_pub = test_node.create_publisher(CameraInfo, 'camera_info', 10)
-    camera_info = CameraInfo(
-        header=Header(frame_id='camera_optical_frame'),
-        width=2048,
-        height=1536,
-        binning_x=4,
-        binning_y=4,
-        k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
     camera_info_pub.publish(camera_info)
     rclpy.spin_once(ipm_service_node, timeout_sec=0.1)
 
@@ -190,7 +187,6 @@ def test_map_point_cloud_invalid_plane():
     test_node = rclpy.node.Node('test')
 
     camera_info_pub = test_node.create_publisher(CameraInfo, 'camera_info', 10)
-    camera_info = CameraInfo()
     camera_info_pub.publish(camera_info)
     rclpy.spin_once(ipm_service_node, timeout_sec=0.1)
 
@@ -220,13 +216,6 @@ def test_map_point_cloud():
     test_node = rclpy.node.Node('test')
 
     camera_info_pub = test_node.create_publisher(CameraInfo, 'camera_info', 10)
-    camera_info = CameraInfo(
-        header=Header(frame_id='camera_optical_frame'),
-        width=2048,
-        height=1536,
-        binning_x=4,
-        binning_y=4,
-        k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
     camera_info_pub.publish(camera_info)
     rclpy.spin_once(ipm_service_node, timeout_sec=0.1)
 

--- a/ipm_service/test/test_ipm_service.py
+++ b/ipm_service/test/test_ipm_service.py
@@ -85,7 +85,7 @@ def test_map_point_invalid_plane():
     test_node = rclpy.node.Node('test')
 
     camera_info_pub = test_node.create_publisher(CameraInfo, 'camera_info', 10)
-    camera_info_pub.publish(camera_info)
+    camera_info_pub.publish(CameraInfo())
     rclpy.spin_once(ipm_service_node, timeout_sec=0.1)
 
     client = test_node.create_client(MapPoint, 'map_point')
@@ -108,7 +108,13 @@ def test_map_point_no_intersection_error():
     test_node = rclpy.node.Node('test')
 
     camera_info_pub = test_node.create_publisher(CameraInfo, 'camera_info', 10)
-    camera_info_pub.publish(camera_info)
+    camera_info_pub.publish(
+        CameraInfo(
+            width=2048,
+            height=1536,
+            binning_x=4,
+            binning_y=4,
+            k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.]))
     rclpy.spin_once(ipm_service_node, timeout_sec=0.1)
 
     client = test_node.create_client(MapPoint, 'map_point')
@@ -187,7 +193,7 @@ def test_map_point_cloud_invalid_plane():
     test_node = rclpy.node.Node('test')
 
     camera_info_pub = test_node.create_publisher(CameraInfo, 'camera_info', 10)
-    camera_info_pub.publish(camera_info)
+    camera_info_pub.publish(CameraInfo())
     rclpy.spin_once(ipm_service_node, timeout_sec=0.1)
 
     point_cloud = create_cloud(


### PR DESCRIPTION
This makes the tests a bit shorter and easier to understand.
I think the tests should pass once #37 is merged.