### PR TITLE
add CameraInfoNotSetException

### DIFF
--- a/ipm_library/ipm_library/exceptions.py
+++ b/ipm_library/ipm_library/exceptions.py
@@ -13,6 +13,12 @@
 # limitations under the License.
 
 
+class CameraInfoNotSetException(Exception):
+    """Raised is a transform is requested without CameraInfo being set."""
+
+    pass
+
+
 class InvalidPlaneException(Exception):
     """Raised if a plane is invalid, i.e. a=b=c=0."""
 

--- a/ipm_library/ipm_library/ipm.py
+++ b/ipm_library/ipm_library/ipm.py
@@ -134,13 +134,13 @@ class IPM:
         :rasies CameraInfoNotSetException if camera info has not been provided
         :raises InvalidPlaneException if the plane is invalid
         """
+        if not self.camera_info_received():
+            raise CameraInfoNotSetException
+
         assert points_header.stamp == plane_msg.header.stamp, \
             'Plane and Point need to have the same time stamp'
         assert self._camera_info.header.frame_id == points_header.frame_id, \
             'Points need to be in the frame described in the camera info message'
-
-        if not self.camera_info_received():
-            raise CameraInfoNotSetException
 
         if not np.any(plane_msg.plane.coef[:3]):
             raise InvalidPlaneException

--- a/ipm_library/ipm_library/ipm.py
+++ b/ipm_library/ipm_library/ipm.py
@@ -16,7 +16,10 @@ from typing import Optional
 
 from ipm_interfaces.msg import PlaneStamped, Point2DStamped
 from ipm_library import utils
-from ipm_library.exceptions import InvalidPlaneException, NoIntersectionError
+from ipm_library.exceptions import (
+    CameraInfoNotSetException,
+    InvalidPlaneException,
+    NoIntersectionError)
 import numpy as np
 from sensor_msgs.msg import CameraInfo
 from std_msgs.msg import Header
@@ -82,6 +85,7 @@ class IPM:
         :param plane: Plane in which the mapping should happen
         :param point: Point that should be mapped
         :param output_frame: TF2 frame in which the output should be provided
+        :rasies CameraInfoNotSetException if camera info has not been provided
         :raise: InvalidPlaneException if the plane is invalid
         :raise: NoIntersectionError if the point is not on the plane
         :returns: The point mapped onto the given plane in the output frame
@@ -126,14 +130,17 @@ class IPM:
             a nx2 numpy array where n is the number of points
         :param points_header: Header for the numpy message containing the frame and time stamp
         :param output_frame: TF2 frame in which the output should be provided
-        :raise: InvalidPlaneException if the plane is invalid
         :returns: The points mapped onto the given plane in the output frame
+        :rasies CameraInfoNotSetException if camera info has not been provided
+        :raises InvalidPlaneException if the plane is invalid
         """
         assert points_header.stamp == plane_msg.header.stamp, \
             'Plane and Point need to have the same time stamp'
-        assert self.camera_info_received(), 'No camera info set'
         assert self._camera_info.header.frame_id == points_header.frame_id, \
             'Points need to be in the frame described in the camera info message'
+
+        if not self.camera_info_received():
+            raise CameraInfoNotSetException
 
         if not np.any(plane_msg.plane.coef[:3]):
             raise InvalidPlaneException

--- a/ipm_library/test/test_ipm.py
+++ b/ipm_library/test/test_ipm.py
@@ -329,4 +329,4 @@ def test_camera_info_not_set():
     """Check CameraInfoNotSetException is raised if camera info is not set."""
     ipm = IPM(tf2.Buffer())
     with pytest.raises(CameraInfoNotSetException):
-        ipm.map_point(PlaneStamped(), Point2D())
+        ipm.map_point(PlaneStamped(), Point2DStamped())

--- a/ipm_library/test/test_ipm.py
+++ b/ipm_library/test/test_ipm.py
@@ -14,7 +14,10 @@
 
 from geometry_msgs.msg import TransformStamped
 from ipm_interfaces.msg import PlaneStamped, Point2DStamped
-from ipm_library.exceptions import InvalidPlaneException, NoIntersectionError
+from ipm_library.exceptions import (
+    CameraInfoNotSetException,
+    InvalidPlaneException,
+    NoIntersectionError)
 from ipm_library.ipm import IPM
 import numpy as np
 import pytest
@@ -320,3 +323,10 @@ def test_map_points_invalid_plane_exception():
     ipm = IPM(tf2.Buffer(), CameraInfo())
     with pytest.raises(InvalidPlaneException):
         ipm.map_points(PlaneStamped(), np.array([]), Header())
+
+
+def test_camera_info_not_set():
+    """Check CameraInfoNotSetException is raised if camera info is not set."""
+    ipm = IPM(tf2.Buffer())
+    with pytest.raises(CameraInfoNotSetException):
+        ipm.map_point(PlaneStamped(), Point2D())


### PR DESCRIPTION
Uses an exception rather than assert, going off suggestions [from this post](https://softwareengineering.stackexchange.com/a/15518).
Tests should pass after #37 is merged.