### PR TITLE
Handle distortion in the ipm

### DIFF
--- a/ipm_image_node/ipm_image_node/ipm.py
+++ b/ipm_image_node/ipm_image_node/ipm.py
@@ -35,17 +35,18 @@ class IPMImageNode(Node):
 
     def __init__(self) -> None:
         super().__init__('ipm_image_node')
+        # Declare params
+        self.declare_parameter('output_frame', 'base_footprint')
+        self.declare_parameter('type', 'mask')
+        self.declare_parameter('scale', 1.0)
+        self.declare_parameter('use_distortion', False)
+
         # We need to create a tf buffer
         self.tf_buffer = tf2.Buffer(cache_time=Duration(seconds=30.0))
         self.tf_listener = tf2.TransformListener(self.tf_buffer, self)
 
         # Create an IPM instance
-        self.ipm = IPM(self.tf_buffer)
-
-        # Declare params
-        self.declare_parameter('output_frame', 'base_footprint')
-        self.declare_parameter('type', 'mask')
-        self.declare_parameter('scale', 1.0)
+        self.ipm = IPM(self.tf_buffer, distortion=self.get_parameter('use_distortion').value)
 
         # Subscribe to camera info
         self.create_subscription(CameraInfo, 'camera_info', self.ipm.set_camera_info, 1)

--- a/ipm_library/ipm_library/ipm.py
+++ b/ipm_library/ipm_library/ipm.py
@@ -35,7 +35,8 @@ class IPM:
     def __init__(
             self,
             tf_buffer: tf2_ros.Buffer,
-            camera_info: Optional[CameraInfo] = None) -> None:
+            camera_info: Optional[CameraInfo] = None,
+            distortion: bool = False) -> None:
         """
         Create a new inverse perspective mapper instance.
 
@@ -44,10 +45,13 @@ class IPM:
             camera intrinsics, camera frame, ...
             The camera info can be updated later on using the setter or
             provided directly if it is unlikly to change
+        :param distortion: Weather to use the distortion coefficients from the camera info.
+            Don't use this if you are using a rectified image.
         """
         # TF needs a listener that is init in the node context, so we need a reference
         self._tf_buffer = tf_buffer
         self.set_camera_info(camera_info)
+        self._distortion = distortion
 
     def set_camera_info(self, camera_info: CameraInfo) -> None:
         """
@@ -178,7 +182,8 @@ class IPM:
             self._camera_info,
             points,
             plane_normal,
-            plane_base_point)
+            plane_base_point,
+            use_distortion=self._distortion)
 
         # Transform output point if output frame if needed
         if output_frame_id not in [None, self._camera_info.header.frame_id]:

--- a/ipm_library/ipm_library/utils.py
+++ b/ipm_library/ipm_library/utils.py
@@ -133,8 +133,7 @@ def get_field_intersection_for_pixels(
     ray_directions[:, :2] = cv2.undistortPoints(
         points.reshape(1, -1, 2).astype(np.float32),
         np.array(camera_info.k).reshape(3, 3),
-        distortion_coefficients,
-        R=np.array(camera_info.r).reshape(3, 3)).reshape(-1, 2)
+        distortion_coefficients).reshape(-1, 2)
 
     # Calculate ray -> plane intersections
     intersections = line_plane_intersections(

--- a/ipm_library/ipm_library/utils.py
+++ b/ipm_library/ipm_library/utils.py
@@ -130,10 +130,11 @@ def get_field_intersection_for_pixels(
 
     # Get the ray directions relative to the camera optical frame for each of the points
     ray_directions = np.ones((points.shape[0], 3))
-    ray_directions[:, :2] = cv2.undistortPoints(
-        points.reshape(1, -1, 2).astype(np.float32),
-        np.array(camera_info.k).reshape(3, 3),
-        distortion_coefficients).reshape(-1, 2)
+    if points.shape[0] > 0:
+        ray_directions[:, :2] = cv2.undistortPoints(
+            points.reshape(1, -1, 2).astype(np.float32),
+            np.array(camera_info.k).reshape(3, 3),
+            distortion_coefficients).reshape(-1, 2)
 
     # Calculate ray -> plane intersections
     intersections = line_plane_intersections(

--- a/ipm_library/package.xml
+++ b/ipm_library/package.xml
@@ -11,11 +11,12 @@
   <depend>geometry_msgs</depend>
   <depend>ipm_interfaces</depend>
   <depend>python3-numpy</depend>
+  <depend>python3-opencv</depend>
   <depend>sensor_msgs</depend>
   <depend>shape_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>tf2</depend>
   <depend>tf2_geometry_msgs</depend>
+  <depend>tf2</depend>
   <depend>vision_msgs</depend>
 
   <test_depend>ament_copyright</test_depend>

--- a/ipm_library/test/test_ipm.py
+++ b/ipm_library/test/test_ipm.py
@@ -36,7 +36,10 @@ camera_info = CameraInfo(
     height=1536,
     binning_x=4,
     binning_y=4,
-    k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.])
+    k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.],
+    d=np.zeros(5),
+    r=np.eye(3).flatten(),
+    )
 
 
 def test_ipm_camera_info():
@@ -127,7 +130,7 @@ def test_ipm_map_points_no_transform():
     # Projection doesn't consider the binning, so we need to correct for that
     point_projected_2d[0] = point_projected_2d[0] / camera_info.binning_x
     point_projected_2d[1] = point_projected_2d[1] / camera_info.binning_y
-    assert np.allclose(points, np.transpose(point_projected_2d), rtol=0.0001), \
+    assert np.allclose(points, np.transpose(point_projected_2d), rtol=0.001, atol=0.001), \
         'Mapped point differs too much'
 
 

--- a/ipm_library/test/test_ipm.py
+++ b/ipm_library/test/test_ipm.py
@@ -38,7 +38,6 @@ camera_info = CameraInfo(
     binning_y=4,
     k=[1338.64532, 0., 1026.12387, 0., 1337.89746, 748.42213, 0., 0., 1.],
     d=np.zeros(5),
-    r=np.eye(3).flatten(),
     )
 
 

--- a/ipm_service/ipm_service/ipm.py
+++ b/ipm_service/ipm_service/ipm.py
@@ -28,11 +28,13 @@ class IPMService(Node):
 
     def __init__(self) -> None:
         super().__init__('ipm_service')
+        # Declare params
+        self.declare_parameter('use_distortion', False)
         # TF handling
         self.tf_buffer = tf2.Buffer(Duration(seconds=5))
         self.tf_listener = tf2.TransformListener(self.tf_buffer, self)
         # Create ipm library instance
-        self.ipm = IPM(self.tf_buffer)
+        self.ipm = IPM(self.tf_buffer, distortion=self.get_parameter('use_distortion').value)
         # Create subs
         self.camera_info_sub = self.create_subscription(
             CameraInfo, 'camera_info', self.ipm.set_camera_info, 1)


### PR DESCRIPTION
Currently, no distortion is considered in the IPM and we assume all inputs come from a rectified image. But this might not always be the case. Many CV approaches also perform well on unrectified images and skipping the rectification can be good in terms of performance. In cases like this, the distortion needs to be accounted for during the inverse perspective mapping. This pr introduces a dep to OpenCV to calculate the ray directions. This is able to account for the distortion. It is slightly slower compared to the previous approach, but it still only takes ~1/100 seconds to convert a reasonably sized image in its entirety (which is not the case most of the time).

Closes #11 